### PR TITLE
refactor: :truck: Make application accessible on default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The machine for deployment can be created in services like Microsoft Azure or Am
 
 - Linux machine with Ubuntu > 20.04 (the recommended is 24.04).
 - Docker installed.
-- Open ports for the applications installed (in this case, ports 3000 for the webapp and 8000 for the gateway service).
+- Open ports for the applications installed (in this case, ports 80 for the webapp and 8000 for the gateway service).
 
 Once you have the virtual machine created, you can install **Docker** using the following instructions:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
     depends_on:
       - gatewayservice
     ports:
-      - "3000:3000"
+      - "80:3000"
 
   gameservice:
     container_name: gameservice-wichat_en1c


### PR DESCRIPTION
Docker-compose changed to make app listen on default port

This commit modifies the docker-compose.yml file to map the host's port 80 to the web application's port within the container. This allows users to access the application via the standard HTTP port without needing to specify a port number in the URL.

**Related issue**: #114 