### PR TITLE
feat(stats): :sparkles: added support for AI games and different modes

### DIFF
--- a/common/src/model.js
+++ b/common/src/model.js
@@ -32,10 +32,11 @@ const gameSchema = new mongoose.Schema({
   hints: { type: Number, required: true },
   config: {
     type: {
-      mode: { type: String, required: true },
+      modes: { type: [{ type: String, required: true }], required: true },
       rounds: { type: Number, required: true },
       time: { type: Number, required: true },
       hints: { type: Number, required: true },
+      isAIGame: { type: Boolean, required: true },
     },
     required: true,
   },

--- a/common/src/model.js
+++ b/common/src/model.js
@@ -36,7 +36,7 @@ const gameSchema = new mongoose.Schema({
       rounds: { type: Number, required: true },
       time: { type: Number, required: true },
       hints: { type: Number, required: true },
-      isAIGame: { type: Boolean, required: true },
+      isAIGame: { type: Boolean, required: true, default: false },
     },
     required: true,
   },

--- a/statservice/src/config.js
+++ b/statservice/src/config.js
@@ -7,7 +7,7 @@ module.exports = {
   mongoUri: process.env.MONGODB_URI ?? "mongodb://localhost:27017/wichat",
   game: {
     config: {
-      modes: ["musicians"],
+      modes: ["musician", "scientist", "actor", "painter", "writer"],
       rounds: { min: 1 },
       time: { min: 10 },
       hints: { min: 0 },

--- a/statservice/src/validation.js
+++ b/statservice/src/validation.js
@@ -84,6 +84,7 @@ module.exports = {
       body("game.config.modes.*", messages.missing)
         .isString()
         .withMessage(messages.notString)
+        .toLowerCase()
         .isIn(config.game.config.modes)
         .withMessage(messages.notValid),
       body("game.config.rounds", messages.missing)

--- a/statservice/src/validation.js
+++ b/statservice/src/validation.js
@@ -75,12 +75,17 @@ module.exports = {
       body("game.config", messages.missing)
         .isObject()
         .withMessage(messages.notObject),
-      body("game.config.mode", messages.missing)
+      body("game.config.isAIGame", messages.missing)
+        .isBoolean()
+        .withMessage(messages.notValid),
+      body("game.config.modes", messages.missing)
+        .isArray()
+        .withMessage(messages.notValidArray),
+      body("game.config.modes.*", messages.missing)
         .isString()
         .withMessage(messages.notString)
-        .toLowerCase()
         .isIn(config.game.config.modes)
-        .withMessage(`Not a valid mode ${config.game.config.modes.toString()}`),
+        .withMessage(messages.notValid),
       body("game.config.rounds", messages.missing)
         .isInt({ min: config.game.config.rounds.min })
         .withMessage(messages.notValidNumber),

--- a/statservice/src/validation.js
+++ b/statservice/src/validation.js
@@ -86,7 +86,7 @@ module.exports = {
         .withMessage(messages.notString)
         .toLowerCase()
         .isIn(config.game.config.modes)
-        .withMessage(messages.notValid),
+        .withMessage(`${messages.notValid}. Valid options are: ${config.game.config.modes.join(", ")}`),
       body("game.config.rounds", messages.missing)
         .isInt({ min: config.game.config.rounds.min })
         .withMessage(messages.notValidNumber),

--- a/statservice/test/data.js
+++ b/statservice/test/data.js
@@ -11,10 +11,11 @@ const game = {
     finished: date4,
   },
   config: {
-    mode: "musicians",
+    modes: ["musician"],
     rounds: 2,
     time: 100,
     hints: 3,
+    isAIGame: false,
   },
   hints: 2,
   questions: [


### PR DESCRIPTION
> [!NOTE]
> This PR is complementary to #132 

# Summary
This pull request introduces updates to the game configuration schema and validation logic to support multiple game modes and an AI game flag.

## Changes
### Schema and Model Updates:
* [`common/src/model.js`](diffhunk://#diff-984693372cc54c240b7b793b684ac66bdb94ca163e04eae6291554ae39cc8ef6L35-R39): Updated the `gameSchema` to replace `mode` with `modes` (an array of strings) and added a new `isAIGame` boolean property to the configuration.

### Configuration Updates:
* [`statservice/src/config.js`](diffhunk://#diff-785c65d5341c18acc83f4cd62e13779f76cab1fdd2a9b04bc61eb26a9d067790L10-R10): Expanded the default game modes to include "musician," "scientist," "actor," "painter," and "writer."

### Validation Updates:
* [`statservice/src/validation.js`](diffhunk://#diff-7c9ccd4f396e0207da04e6e1e18dbfd5085cd541e48d0452f40756a34692616aL78-R88): Updated validation logic to handle the new `modes` array and `isAIGame` boolean. Added checks to ensure `modes` is an array of valid strings and `isAIGame` is a boolean.

### Test Data Updates:
* [`statservice/test/data.js`](diffhunk://#diff-e503aa352d1b64b2e0657cfd2998690730155662e80031265a0f75a2dd31a070L14-R18): Updated test data to reflect the new `modes` array and `isAIGame` property.